### PR TITLE
Implement test runner

### DIFF
--- a/iris/iris.py
+++ b/iris/iris.py
@@ -34,11 +34,26 @@ class Iris(object):
                     exit(1)
                 else:
                     tests_package = tests_directory
-                    logger.info("Module for tests: %s", tests_package)
+                    logger.info("Test package: %s", tests_package)
                     logger.info("List of tests to execute: [%s]" % ', '.join(map(str, tests_list)))
             else:
                 logger.error("Path: %s does not exist. Exiting program ...", tests_directory)
                 exit(1)
+        elif args.test:
+            test_name = str(args.test + ('.py' if not args.test.endswith('.py') else '')).strip()
+            tests_directory =  os.path.join(os.path.split(__file__)[0], "tests");
+            for dirpath, subdirs, files in os.walk(tests_directory):
+                if test_name in files:
+                    tests_list.append(os.path.splitext(test_name)[0])
+                    tests_package = os.path.join(os.path.split(__file__)[0], dirpath.strip())
+            if len(tests_list) == 0:
+                logger.error("Could not locate %s . Exiting program ...", str(test_name))
+                exit(1)
+            else:
+                logger.info("FOUND %s", test_name)
+
+        print tests_package
+
 
         self.module_dir = get_module_dir()
         self.platform = get_platform()

--- a/iris/iris.py
+++ b/iris/iris.py
@@ -7,31 +7,44 @@ import sys
 import test_runner
 from api.core import *
 from logger.iris_logger import *
+import argparse
 
 class Iris(object):
 
     def __init__(self):
         logger = getLogger(__name__)
-        logger.info('This is our main app')
 
-        """
-        Things to do here:
-            * argument parsing
-            * download and install Firefox
-            * set up logging
-            * save data to 'self' object
-        """
+        parser = argparse.ArgumentParser(description='Run Iris testsuit', prog='iris')
+        parser.add_argument('-d', '--directory', type=str, metavar='tests_directory', help='Directory where tests are located')
+        parser.add_argument('-t', '--test', type=str, metavar='test_name.py', help='Test name')
+        args = parser.parse_args()
+
+        tests_list = []
+        tests_package = []
+
+        if args.directory:
+            tests_directory =  os.path.join(os.path.split(__file__)[0], args.directory.strip())
+            if (os.path.isdir(tests_directory)):
+                logger.info("Path %s found. Checking content ...", tests_directory)
+                for file in os.listdir(tests_directory):
+                    if file.endswith(".py") and not file.startswith("__init__"):
+                        tests_list.append(os.path.splitext(file)[0])
+                if len(tests_list) == 0:
+                    logger.error("Directory %s does not contain test files. Exiting program ...", tests_directory)
+                    exit(1)
+                else:
+                    tests_package = tests_directory
+                    logger.info("Module for tests: %s", tests_package)
+                    logger.info("List of tests to execute: [%s]" % ', '.join(map(str, tests_list)))
+            else:
+                logger.error("Path: %s does not exist. Exiting program ...", tests_directory)
+                exit(1)
+
         self.module_dir = get_module_dir()
         self.platform = get_platform()
         self.os = get_os()
-
-        # Checking for arguments
-        # Can throw if invoked via java
-        try:
-            if len (sys.argv[1]):
-                print "args: %s" % ' '.join(sys.argv[1:])
-        except:
-            pass
+        self.tests_package = tests_package
+        self.tests_list = tests_list
 
         test_runner.run(self)
 

--- a/iris/test_runner.py
+++ b/iris/test_runner.py
@@ -4,36 +4,22 @@
 
 from api.helpers.general import *
 from logger.iris_logger import *
+import os
+import sys
+import importlib
 
-# Temporarily hard-coded for just a few tests
-from tests.experiments import tabs, back_forward, basic_url, amazon_bookmarks, deactivate_activity_stream
-
-
-# The test runner will be written so that it can iterate through the "tests"
-# directory and dynamically import what it finds.
-#
-# Additionally, we will create logic to only run certain tests and test sets.
 logger = getLogger(__name__)
 
 def run(app):
     logger.info("Running tests")
-
+    sys.path.append(app.tests_package)
     # Start with no saved profiles
     clean_profiles()
 
-    # Hard-code for now, but we will build a dynamic array of tests to run later
-    all_tests = []
-    all_tests.append(tabs)
-    all_tests.append(back_forward)
-    all_tests.append(basic_url)
-    all_tests.append(amazon_bookmarks)
-    all_tests.append(deactivate_activity_stream)
-
-
-# Then we'd dynamically call test() and run on this list of test cases
-    for module in all_tests:
-
-        current = module.test(app)
+    # Then we'd dynamically call test() and run on this list of test cases
+    for module in app.tests_list:
+        current_module = importlib.import_module(module)
+        current = current_module.test(app)
         logger.info("Running test case: %s " % current.meta)
 
         # Initialize and launch Firefox


### PR DESCRIPTION
The current implementation works for a single provided folder or test name. It could be extended to run for multiple folders or test files
Usage:
iris -d tests\experiments - will run all tests from the tests\experiments folder
iris -d tests - will not run any tests (deep search needs to be implemented using os.walk())
iris -t base_url.py or iris -t base_url - will run the base_url.py test (you can provide test name with or without .py extension, it is automatically treated)
