### PR TITLE
verify tests

### DIFF
--- a/iris/test_runner.py
+++ b/iris/test_runner.py
@@ -23,21 +23,24 @@ def run(app):
 
     for module in app.test_list:
         current_module = importlib.import_module(module)
-        current = current_module.test(app)
-        logger.info("Running test case: %s " % current.meta)
+        try:
+            current = current_module.test(app)
+            logger.info("Running test case: %s " % current.meta)
 
-        # Initialize and launch Firefox
-        current.setup()
+            # Initialize and launch Firefox
+            current.setup()
 
-        # Verify that Firefox has launched
-        confirm_firefox_launch()
+            # Verify that Firefox has launched
+            confirm_firefox_launch()
 
-        # Run the test logic
-        current.run()
+            # Run the test logic
+            current.run()
 
-        # Quit Firefox
-        current.teardown()
-        confirm_firefox_quit()
+            # Quit Firefox
+            current.teardown()
+            confirm_firefox_quit()
+        except AttributeError:
+            logger.warning('[%s] is not a test file. Skipping ...', module)
 
 
     # We may remove profiles here, but likely still in use and can't do it yet
@@ -72,7 +75,7 @@ def load_tests(app):
         logger.debug("Path %s found. Checking content ...", tests_directory)
         for dirpath, subdirs, files in os.walk(tests_directory):
             for file in files:
-                if file.endswith(".py") and not file.startswith("__init__"):
+                if file.endswith(".py") and not file.startswith("__"):
                     app.test_list.append(os.path.splitext(file)[0])
                     if not dirpath in app.test_packages:
                         app.test_packages.append(dirpath)
@@ -85,4 +88,3 @@ def load_tests(app):
     else:
         logger.error("Path: %s does not exist. Exiting program ...", tests_directory)
         exit(1)
-


### PR DESCRIPTION
If a .py file is not a test will throw an AttributeError Exception. If the exception is thrown it will log a warning and skip the file